### PR TITLE
chore(README): fix Usage command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This will install Snackify globally on your machine, allowing you to use it in a
 Navigate to the root directory of your Expo project and run:
 
 ```bash
-npx create snack
+npx create-snack
 ```
 
 The command scans all the files in your Expo project, excluding `node_modules` and `.git`, and creates a new Expo Snack. Upon completion, it provides a URL to the created Expo Snack.


### PR DESCRIPTION
## Before

`npx create snack` is invalid.

```console
% npx create snack
npm ERR! could not determine executable to run

[...]
```

## After

`npx create-stack` is the correct invocation.

```console
% npx create-snack
Need to install the following packages:
create-snack@1.0.5
Ok to proceed? (y) 
```
